### PR TITLE
Parse to time

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,7 +1,6 @@
 package trakt
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -115,7 +114,6 @@ func (c *Client) applyRequestHeaders(req *Request) {
 
 	if tokenAuth, ok := c.AuthMethod.(TokenAuth); ok {
 		req.Header.Set("Authorization", tokenAuth.String())
-		fmt.Println(tokenAuth.AccessToken)
 	}
 
 	// Go doesn't apply `Host` on the header, instead it consults `Request.Host`

--- a/episodes.go
+++ b/episodes.go
@@ -1,6 +1,9 @@
 package trakt
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 var (
 	ShowSeasonEpisodesURL = Hyperlink("shows/{showTraktID}/seasons/{seasonNumber}/episodes")
@@ -25,8 +28,8 @@ func (r *EpisodesService) AllBySeason(showTraktID int, seasonNumber int) (episod
 
 // Episode struct for the Trakt v2 API
 type Episode struct {
-	AvailableTranslations []string `json:"available_translations"`
-	FirstAired            string   `json:"first_aired"`
+	AvailableTranslations []string   `json:"available_translations"`
+	FirstAired            *time.Time `json:"first_aired"`
 	IDs                   struct {
 		Imdb   string `json:"imdb"`
 		Tmdb   int    `json:"tmdb"`


### PR DESCRIPTION
I promise this is the last one for today. :)

This PR changes the parse target for the 'first_aired' field in the JSON to a `time.Time`. 

(Ow, and removes some stray debug fmt)
