### PR TITLE
Export the constants.

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,12 +11,12 @@ import (
 )
 
 func NewClient(apiKey string, authMethod AuthMethod) *Client {
-	return NewClientWith(traktAPIURL, userAgent, apiKey, authMethod, nil)
+	return NewClientWith(TraktAPIURL, UserAgent, apiKey, authMethod, nil)
 }
 
-func NewClientWith(baseURL string, userAgent string, apiKey string, authMethod AuthMethod, httpClient *http.Client) *Client {
+func NewClientWith(baseURL string, UserAgent string, apiKey string, authMethod AuthMethod, httpClient *http.Client) *Client {
 	client, _ := sawyer.NewFromString(baseURL, httpClient)
-	return &Client{Client: client, UserAgent: userAgent, ApiKey: apiKey, AuthMethod: authMethod}
+	return &Client{Client: client, UserAgent: UserAgent, ApiKey: apiKey, AuthMethod: authMethod}
 }
 
 type Client struct {
@@ -107,9 +107,9 @@ func (c *Client) upload(uploadUrl *url.URL, asset io.ReadCloser, contentType str
 }
 
 func (c *Client) applyRequestHeaders(req *Request) {
-	req.Header.Set("Accept", defaultMediaType)
+	req.Header.Set("Accept", DefaultMediaType)
 	req.Header.Set("User-Agent", c.UserAgent)
-	req.Header.Set("trakt-api-version", traktAPIVersion)
+	req.Header.Set("trakt-api-version", TraktAPIVersion)
 	req.Header.Set("trakt-api-key", c.ApiKey)
 
 	if tokenAuth, ok := c.AuthMethod.(TokenAuth); ok {

--- a/request.go
+++ b/request.go
@@ -53,7 +53,7 @@ func (r *Request) Options(output interface{}) (*Response, error) {
 }
 
 func (r *Request) setBody(input interface{}) {
-	mtype, _ := mediatype.Parse(defaultMediaType)
+	mtype, _ := mediatype.Parse(DefaultMediaType)
 	r.Request.SetBody(mtype, input)
 }
 

--- a/trakt.go
+++ b/trakt.go
@@ -1,9 +1,9 @@
 package trakt
 
 const (
-	traktAPIURL      = "https://api.trakt.tv"
-	traktAPIVersion  = "2"
-	userAgent        = "Trakt Go " + version
-	version          = "0.0.1"
-	defaultMediaType = "application/json"
+	TraktAPIURL      = "https://api.trakt.tv"
+	TraktAPIVersion  = "2"
+	UserAgent        = "Trakt Go " + Version
+	Version          = "0.0.1"
+	DefaultMediaType = "application/json"
 )


### PR DESCRIPTION
Now users can use them when using NewClientWith.

Trakt changed their API to `https://api-v2launch.trakt.tv`. This required me to use `NewClientWith`, which accepts many arguments but I wanted to use the defaults except for the API URL.
